### PR TITLE
Remove Unused Services from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
             - sail
         depends_on:
             - mysql
-            - redis
-            - meilisearch
-            - mailpit
-            - selenium
+            # - redis
+            # - meilisearch
+            # - mailpit
+            # - selenium
     mysql:
         image: 'mysql/mysql-server:8.0'
         ports:
@@ -51,55 +51,55 @@ services:
                 - '-p${DB_PASSWORD}'
             retries: 3
             timeout: 5s
-    redis:
-        image: 'redis:alpine'
-        ports:
-            - '${FORWARD_REDIS_PORT:-6379}:6379'
-        volumes:
-            - 'sail-redis:/data'
-        networks:
-            - sail
-        healthcheck:
-            test:
-                - CMD
-                - redis-cli
-                - ping
-            retries: 3
-            timeout: 5s
-    meilisearch:
-        image: 'getmeili/meilisearch:latest'
-        ports:
-            - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
-        environment:
-            MEILI_NO_ANALYTICS: '${MEILISEARCH_NO_ANALYTICS:-false}'
-        volumes:
-            - 'sail-meilisearch:/meili_data'
-        networks:
-            - sail
-        healthcheck:
-            test:
-                - CMD
-                - wget
-                - '--no-verbose'
-                - '--spider'
-                - 'http://127.0.0.1:7700/health'
-            retries: 3
-            timeout: 5s
-    mailpit:
-        image: 'axllent/mailpit:latest'
-        ports:
-            - '${FORWARD_MAILPIT_PORT:-1025}:1025'
-            - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
-        networks:
-            - sail
-    selenium:
-        image: seleniarm/standalone-chromium
-        extra_hosts:
-            - 'host.docker.internal:host-gateway'
-        volumes:
-            - '/dev/shm:/dev/shm'
-        networks:
-            - sail
+    # redis:
+    #     image: 'redis:alpine'
+    #     ports:
+    #         - '${FORWARD_REDIS_PORT:-6379}:6379'
+    #     volumes:
+    #         - 'sail-redis:/data'
+    #     networks:
+    #         - sail
+    #     healthcheck:
+    #         test:
+    #             - CMD
+    #             - redis-cli
+    #             - ping
+    #         retries: 3
+    #         timeout: 5s
+    # meilisearch:
+    #     image: 'getmeili/meilisearch:latest'
+    #     ports:
+    #         - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
+    #     environment:
+    #         MEILI_NO_ANALYTICS: '${MEILISEARCH_NO_ANALYTICS:-false}'
+    #     volumes:
+    #         - 'sail-meilisearch:/meili_data'
+    #     networks:
+    #         - sail
+    #     healthcheck:
+    #         test:
+    #             - CMD
+    #             - wget
+    #             - '--no-verbose'
+    #             - '--spider'
+    #             - 'http://127.0.0.1:7700/health'
+    #         retries: 3
+    #         timeout: 5s
+    # mailpit:
+    #     image: 'axllent/mailpit:latest'
+    #     ports:
+    #         - '${FORWARD_MAILPIT_PORT:-1025}:1025'
+    #         - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
+    #     networks:
+    #         - sail
+    # selenium:
+    #     image: seleniarm/standalone-chromium
+    #     extra_hosts:
+    #         - 'host.docker.internal:host-gateway'
+    #     volumes:
+    #         - '/dev/shm:/dev/shm'
+    #     networks:
+    #         - sail
 networks:
     sail:
         driver: bridge


### PR DESCRIPTION
Description:
This pull request removes the Redis, MeiliSearch, Selenium, and Mailpit services from the docker-compose.yml file. These services are not currently being used in our project and removing them will streamline the Docker environment, reduce resource usage, and improve overall performance.

Changes Made:
Removed the Redis service.
Removed the MeiliSearch service.
Removed the Selenium service.
Removed the Mailpit service.
Updated relevant parts of the docker-compose.yml to ensure the remaining services continue to function as expected.

Reason for Changes:
Redis: Not used for session management or caching in the current application setup.
MeiliSearch: The project does not require a full-text search engine at this time.
Selenium: Browser-based automated tests are not being utilized in the current development process.
Mailpit: Email functionality is not being tested locally, so Mailpit is unnecessary.

Impact:
Docker environment setup is now more lightweight and easier to manage.
Reduces the startup time and resource consumption of the Docker containers.

Testing:
Verified that the application starts successfully with the modified docker-compose.yml.
Ensured that the application functions as expected without the removed services.
Notes:
If we need any of these services in the future, they can easily be reintroduced by restoring their configurations from version control.

