### PR TITLE
Feature: Delete and Restore Saved Words

### DIFF
--- a/app/Http/Controllers/Myphrases/DeleteSavedWordController.php
+++ b/app/Http/Controllers/Myphrases/DeleteSavedWordController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Myphrases;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class DeleteSavedWordController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Myphrases/DeleteSavedWordController.php
+++ b/app/Http/Controllers/Myphrases/DeleteSavedWordController.php
@@ -3,15 +3,32 @@
 namespace App\Http\Controllers\Myphrases;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\DeleteSavedWordRequest;
+use App\Services\MyphraseService;
+use Exception;
 use Illuminate\Http\Request;
 
 class DeleteSavedWordController extends Controller
 {
-    /**
-     * Handle the incoming request.
-     */
-    public function __invoke(Request $request)
+
+    protected $myphraseService;
+
+    public function __construct(MyphraseService $myphraseService)
     {
-        //
+        $this->myphraseService = $myphraseService;
+    }
+
+    public function __invoke(DeleteSavedWordRequest $request)
+    {
+        $validated = $request->validated();
+        try {
+
+            $deletedWord = $this->myphraseService->deleteSavedWord($validated['word_id']);
+            if ($deletedWord) return response()->json(['message' => 'the word deleted successfully.', 'data' => $deletedWord], 200);
+            return response()->json(['message' => 'the word not found'], 404);
+        } catch (Exception $e) {
+
+            return response()->json(['message' => 'unexpected error occured while deleting word'], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Myphrases/RestoreDeleteWordController.php
+++ b/app/Http/Controllers/Myphrases/RestoreDeleteWordController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\RestoreDeletedWordRequest;
 use App\Services\MyphraseService;
 use Exception;
+use Illuminate\Support\Facades\Log;
 
 class RestoreDeleteWordController extends Controller
 {
@@ -17,15 +18,17 @@ class RestoreDeleteWordController extends Controller
     }
     public function __invoke(RestoreDeletedWordRequest $request)
     {
+        Log::alert('restore started: ' . json_encode($request));
 
         $validated = $request->validated();
 
         try {
             $response = $this->myphraseService->restoreSoftDeletedWord($validated['word_id']);
-            if ($request) return response()->json(['message' => 'successfully restore the word', 'data' => $response['word_id']], 200);
+            if ($response) return response()->json(['message' => 'successfully restore the word', 'data' => $response['word_id']], 200);
             return response()->json(['message' => 'the word not found'], 404);
-        } catch (Exception $e) {
-            return response()->json(['message' => 'unexprected error occured while restore the word'], 500);
+        } catch (\Exception $e) {
+            Log::error('データの削除中にエラーが発生しました', ['error' => $e->getMessage()]); // 修正: 配列形式に
+            return response()->json(['message' => 'unexpected error occured while restore the word.'], 500);
         }
     }
 }

--- a/app/Http/Controllers/Myphrases/RestoreDeleteWordController.php
+++ b/app/Http/Controllers/Myphrases/RestoreDeleteWordController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Myphrases;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\RestoreDeletedWordRequest;
+use App\Services\MyphraseService;
+use Exception;
+
+class RestoreDeleteWordController extends Controller
+{
+    protected $myphraseService;
+
+    public function __construct(MyphraseService $myphraseService)
+    {
+        $this->myphraseService = $myphraseService;
+    }
+    public function __invoke(RestoreDeletedWordRequest $request)
+    {
+
+        $validated = $request->validated();
+
+        try {
+            $response = $this->myphraseService->restoreSoftDeletedWord($validated['word_id']);
+            if ($request) return response()->json(['message' => 'successfully restore the word', 'data' => $response['word_id']], 200);
+            return response()->json(['message' => 'the word not found'], 404);
+        } catch (Exception $e) {
+            return response()->json(['message' => 'unexprected error occured while restore the word'], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/RestoreDeleteWord.php
+++ b/app/Http/Controllers/RestoreDeleteWord.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class RestoreDeleteWord extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/DeleteSavedWordRequest.php
+++ b/app/Http/Requests/DeleteSavedWordRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteSavedWordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            "word_id" => 'required | integer',
+        ];
+    }
+}

--- a/app/Http/Requests/RestoreDeletedWordRequest.php
+++ b/app/Http/Requests/RestoreDeletedWordRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RestoreDeletedWordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            "word_id" => 'required | integer',
+        ];
+    }
+}

--- a/app/Models/Language.php
+++ b/app/Models/Language.php
@@ -9,6 +9,7 @@ class Language extends Model
 {
     use HasFactory;
 
+    public $timestamps = false; 
     public function words()
     {
         return $this->hasMany(Word::class, 'language_code', 'language_code');

--- a/app/Models/Word.php
+++ b/app/Models/Word.php
@@ -4,10 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 
 class Word extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $fillable = ['user_id', 'language_code', 'word'];
 

--- a/app/Repositories/MyphraseRepository.php
+++ b/app/Repositories/MyphraseRepository.php
@@ -117,7 +117,7 @@ class MyphraseRepository implements MyphraseRepositoryInterface
             foreach ($wordIds as $wordId) {
                 $isExists =  DB::table('phrase_word')->where('word_id', $wordId)->exists();
                 if ($isExists) continue;
-                Word::find($wordId)->delete();
+                Word::find($wordId)->forceDelete();
             }
             DB::commit();
         } catch (\Exception $e) {
@@ -159,5 +159,38 @@ class MyphraseRepository implements MyphraseRepositoryInterface
             $phrasesValue
         );
         return $phraseArray;
+    }
+
+    /**
+     *SoftDelete saved words
+     *@param integer word id from client
+     *@return ?Word word object or null(if failed)
+     */
+
+    public function deleteWord($wordId): ?Word
+    {
+        $word = Word::find($wordId);
+
+        if (!$word) {
+            return null;
+        }
+        $word->delete();
+        return $word;
+    }
+
+    /**
+     *SoftDelete saved words
+     *@param integer word id from client
+     *@return ?Word word object or null(if failed)
+     */
+
+    public function restoreWord($wordId): ?Word
+    {
+        $word = Word::withTrashed()->where('id', $wordId)->first();
+        if (!$word) {
+            return null;
+        }
+        $word->restore();
+        return $word;
     }
 }

--- a/app/Repositories/MyphraseRepository.php
+++ b/app/Repositories/MyphraseRepository.php
@@ -142,11 +142,14 @@ class MyphraseRepository implements MyphraseRepositoryInterface
         $wordPhrasesArray = $wordsByUser->map(function ($item) {
             // dd($item);
             return [$item['word'] => [
+                'wordId' => $item->id,
+                'phraseIds' => $item->phrases->map(function ($phrase) {
+                    return $phrase->id;
+                }),
                 'phrases' => $this->createPhraseArray($item['phrases']->toArray()),
                 'language' => $item->language->name
             ]];
         });
-
         return $wordPhrasesArray->toArray();
     }
 

--- a/app/Services/MyphraseService.php
+++ b/app/Services/MyphraseService.php
@@ -2,8 +2,10 @@
 
 namespace App\Services;
 
+use App\Models\Word;
 use App\Repositories\LanguageRepository;
 use App\Repositories\MyphraseRepository;
+use Exception;
 
 class MyphraseService
 {
@@ -57,5 +59,33 @@ class MyphraseService
     public function getAllSavedPhrasesByUser(int $userId): array
     {
         return  $this->myphraseRepository->getUserWordsWithPhrases($userId);
+    }
+
+    /**
+     * softDelete selected word
+     * @param int $wordId
+     * @return array ex ["study": ['phrases'=>["study is ...", "the obsolate study.."], 'language' => 'English (US)'], "obsolate":['phrases'=>["the obsolate study..."],'languages'=>'English (US)']] 
+     */
+    public function deleteSavedWord(int $wordId): ?Word
+    {
+        try {
+            return  $this->myphraseRepository->deleteWord($wordId);
+        } catch (Exception $e) {
+            throw new Exception("failed to soft delete the word");
+        }
+    }
+
+    /**
+     * restore selected word
+     * @param int $wordId
+     * @return array ex ["study": ['phrases'=>["study is ...", "the obsolate study.."], 'language' => 'English (US)'], "obsolate":['phrases'=>["the obsolate study..."],'languages'=>'English (US)']] 
+     */
+    public function restoreSoftDeletedWord(int $wordId): ?Word
+    {
+        try {
+            return  $this->myphraseRepository->restoreWord($wordId);
+        } catch (Exception $e) {
+            throw new Exception('failed to restore the word');
+        }
     }
 }

--- a/app/Services/MyphraseService.php
+++ b/app/Services/MyphraseService.php
@@ -64,7 +64,7 @@ class MyphraseService
     /**
      * softDelete selected word
      * @param int $wordId
-     * @return array ex ["study": ['phrases'=>["study is ...", "the obsolate study.."], 'language' => 'English (US)'], "obsolate":['phrases'=>["the obsolate study..."],'languages'=>'English (US)']] 
+     * @return array ex 
      */
     public function deleteSavedWord(int $wordId): ?Word
     {

--- a/database/factories/LanguageFactory.php
+++ b/database/factories/LanguageFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Language>
+ */
+class LanguageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'language_code' => 'en-US',
+            'name' => 'English (US)'
+        ];
+    }
+}

--- a/database/factories/WordFactory.php
+++ b/database/factories/WordFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Language;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Word>
+ */
+class WordFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'language_code' => Language::factory()->create()->language_code,
+            'word' => '滔滔不绝',
+            'display_count' => 1,
+            'is_favorite' => false,
+            'created_at' => now(),
+            'updated_at' => null,
+            'deleted_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2024_07_20_101014_create_words_table.php
+++ b/database/migrations/2024_07_20_101014_create_words_table.php
@@ -17,10 +17,10 @@ return new class extends Migration
             $table->char('language_code', 5)->nullable();
             $table->string('word');
             $table->integer('display_count')->default(1);
-            $table->boolean('is_archived')->default(false);
+            $table->boolean('is_favorite')->default(false);
             $table->timestamps();
-
             $table->foreign('language_code')->references('language_code')->on('languages')->onDelete('set null');
+            $table->softDeletes();
         });
     }
 
@@ -32,6 +32,7 @@ return new class extends Migration
         Schema::table('words', function (Blueprint $table) {
             $table->dropForeign(['user_id']);
             $table->dropForeign(['language_code']);
+            $table->dropSoftDeletes();
         });
 
         Schema::dropIfExists('words');

--- a/docker-compose-dev-override.yml
+++ b/docker-compose-dev-override.yml
@@ -1,5 +1,5 @@
 services:
-    laravel.phrasewave:
+    laravel.test:
         build:
             context: ./vendor/laravel/sail/runtimes/8.3
             dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-    laravel.phrasewave:
+    laravel.test:
         build:
             context: ./vendor/laravel/sail/runtimes/8.3
             dockerfile: Dockerfile

--- a/e AppServicesMyphraseService
+++ b/e AppServicesMyphraseService
@@ -1,0 +1,27 @@
+[34m 0[39m: use app/Repositories/MyphraseRepository.php
+[34m 1[39m: use app/Repositories/MyphraseRepository;
+[34m 2[39m: use App\Repositories\MyphraseRepository;
+[34m 3[39m: $repository = new MyphraseRepository();
+[34m 4[39m: $repository->deleteWord(1);
+[34m 5[39m: use App\Repositories\MyphraseRepository;
+[34m 6[39m: $repository = new MyphraseRepository();
+[34m 7[39m: $repository->restoreWord(1);
+[34m 8[39m: history
+[34m 9[39m: use App\Repositories\MyphraseRepository;
+[34m10[39m: $repository = new MyphraseRepository();
+[34m11[39m: $repository->restoreWord(1);
+[34m12[39m: use App\Services\MyphraseService
+[34m13[39m: $myphraseService = new MyphraseService
+[34m14[39m: ;
+[34m15[39m: history
+[34m16[39m: use App\Repositories\MyphraseRepository;
+[34m17[39m: use App\Repositories\LanguageRepository;
+[34m18[39m: $myphraseRepository = new MyphraseRepository();
+[34m19[39m: $languageRepository = new LanguageRepository();
+[34m20[39m: use App\Models\Language;
+[34m21[39m: $language = new Language();
+[34m22[39m: $languageRepository = new LanguageRepository($language);
+[34m23[39m: $myphraseService = new MyphraseService($myphraseRepository,$languageRepository);
+[34m24[39m: $myphraseService->deleteSavedWord(2);
+[34m25[39m: history
+[34m26[39m: $repository = new MyphraseRepository();

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,10 @@ use App\Http\Controllers\Generate\GeneratePhrasesController;
 use App\Http\Controllers\Languages\GetAllLanguagesController;
 use App\Http\Controllers\Myphrases\CreateMyphraseController;
 use App\Http\Controllers\Myphrases\DeleteMyphraseController;
+use App\Http\Controllers\Myphrases\DeleteSavedWordController;
 use App\Http\Controllers\Myphrases\GetMyphraseController;
+use App\Http\Controllers\Myphrases\RestoreDeleteWord;
+use App\Http\Controllers\Myphrases\RestoreDeleteWordController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -19,6 +22,8 @@ Route::middleware(['auth:sanctum'])->group(function () {
 });
 
 
+Route::delete('/myphrases/word', DeleteSavedWordController::class);
+Route::post('/myphrases/word/restore', RestoreDeleteWordController::class);
 
 
 Route::get('/languages', GetAllLanguagesController::class);

--- a/tests/Unit/MyphraseServiceTest.php
+++ b/tests/Unit/MyphraseServiceTest.php
@@ -2,25 +2,35 @@
 
 namespace Tests\Unit;
 
+use App\Models\Word;
 use App\Repositories\LanguageRepository;
 use App\Repositories\MyphraseRepository;
 use App\Services\MyphraseService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 use function PHPUnit\Framework\assertEquals;
 
 class MyphraseServiceTest extends TestCase
 {
+    use RefreshDatabase;
     protected $myphraseService;
     protected $myphraseRepositoryMock;
     protected $languageRepositoryMock;
 
     public function setUp(): void
     {
+        parent::setUp();
         $this->myphraseRepositoryMock = Mockery::mock(MyphraseRepository::class);
         $this->languageRepositoryMock = Mockery::mock(LanguageRepository::class);
         $this->myphraseService = new MyphraseService($this->myphraseRepositoryMock, $this->languageRepositoryMock);
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 
     /**
@@ -54,5 +64,26 @@ class MyphraseServiceTest extends TestCase
         $result = $this->myphraseService->createMyphrase($newPhraseData);
 
         assertEquals($expectedObject, $result);
+    }
+
+    /**
+     * test that delete word correctly
+     *@test
+     *@return void
+     */
+    public function test_delete_word_success(): void
+    {
+        $word = Word::factory()->create();
+
+        $this->myphraseRepositoryMock
+            ->shouldReceive('deleteWord')
+            ->with($word->id)
+            ->once()
+            ->andReturn($word);
+
+        $result = $this->myphraseRepositoryMock->deleteWord($word->id);
+
+        $this->assertInstanceOf(Word::class, $result);
+        $this->assertEquals($word->id, $result->id);
     }
 }


### PR DESCRIPTION
Overview:
This feature adds the ability for users to delete saved words and restore them if needed. It introduces two new API endpoints that handle word deletion and restoration, providing a seamless user experience for managing saved phrases.

Development Details:
Endpoint 1: Delete a Saved Word

URL: /api/myphrases/word
Method: DELETE
Description: This endpoint allows users to delete a specific saved word from their phrase list. Once deleted, the word is flagged for potential restoration rather than being permanently removed from the database.
Endpoint 2: Restore a Deleted Word

URL: /api/myphrases/word/restore
Method: POST
Description: This endpoint allows users to restore a previously deleted word, returning it to their saved phrase list. It reverts the soft delete status of the word.
Changes Implemented:
Added DELETE and POST methods to handle word deletion and restoration.
Updated the word status management in the database to support soft delete and restoration functionality.
