### PR TITLE
FIX migration file

### DIFF
--- a/database/migrations/2024_10_06_022041_add_deleted_at_to_words_table.php
+++ b/database/migrations/2024_10_06_022041_add_deleted_at_to_words_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('words', function (Blueprint $table) {
-            // $table->softDeletes();
+            $table->softDeletes();
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('words', function (Blueprint $table) {
-            // $table->dropSoftDeletes();
+            $table->dropSoftDeletes();
         });
     }
 };


### PR DESCRIPTION
Changes:
Recreated the migration file to add the deleted_at column to the words table. The previous migration had the column commented out, so it wasn’t added.

Testing:
Tested the migration in the local environment, and the column was added successfully.

Impact:
Database size: Adding a new column will increase the size of the table, though it’s typically minimal for a single column.
Soft delete functionality: If soft deletes are now enabled, records will not be permanently deleted when using standard delete methods. This could change how data is handled in your application.